### PR TITLE
fix build on 32 bit arm on FreeBSD 14.1 and later

### DIFF
--- a/hotspot/src/os/bsd/vm/os_perf_bsd.cpp
+++ b/hotspot/src/os/bsd/vm/os_perf_bsd.cpp
@@ -57,6 +57,12 @@
        * with the same name.
        */
       #define _MACHINE_PCB_H_
+      /*
+       * do not redefine breakpoint on armv7
+       */
+      #ifdef __arm__
+        #define _MACHINE_CPUFUNC_H_
+      #endif
     #endif
     #include <sys/user.h>
   #endif


### PR DESCRIPTION
Fixes:
```
In file included from /wrkdirs/usr/ports/java/openjdk8/work/jdk8u-jdk8u422-b05.1/hotspot/src/os/bsd/vm/os_perf_bsd.cpp:61: In file included from /usr/include/sys/user.h:51:
In file included from /usr/include/vm/pmap.h:88:
In file included from /usr/include/machine/pmap.h:48: In file included from /usr/include/sys/systm.h:46: /usr/include/machine/cpufunc.h:184:1: error: static declaration of 'breakpoint' follows non-static declaration
  184 | breakpoint(void)
      | ^
/wrkdirs/usr/ports/java/openjdk8/work/jdk8u-jdk8u422-b05.1/hotspot/src/share/vm/utilities/globalDefinitions_gcc.hpp:224:17: note: previous declaration is here
  224 | extern "C" void breakpoint();
      |                 ^
```

This was also committed to the ports tree as a patch to the port.
https://cgit.freebsd.org/ports/commit/?id=23aba7204c39589899e397b166f170b27653f042