### PR TITLE
Fix no return from get_loaded_modules_info

### DIFF
--- a/hotspot/src/os/bsd/vm/os_bsd.cpp
+++ b/hotspot/src/os/bsd/vm/os_bsd.cpp
@@ -1802,10 +1802,10 @@ int os::get_loaded_modules_info(os::LoadedModulesCallbackFunc callback, void *pa
       return 1;
     }
   }
-  return 0;
 #else
   return 1;
 #endif
+  return 0;
 }
 
 void os::print_os_info_brief(outputStream* st) {


### PR DESCRIPTION
This work was sponsored by The FreeBSD Foundation




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
